### PR TITLE
Fix failing case-sensitive regexes in tests

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -8,4 +8,4 @@ use_ok "Tie::DataUUID";
 tie my $foo, "Tie::DataUUID";
 is(ref tied $foo, "Tie::DataUUID", "right class");
 ok($foo ne $foo, "it changes");
-like("$foo $foo", "/[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12} [A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}/", "right looking string");
+like("$foo $foo", "/[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12} [A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}/i", "right looking string");

--- a/t/02export.t
+++ b/t/02export.t
@@ -7,4 +7,4 @@ use Tie::DataUUID qw($uuid);
 
 is(ref tied $uuid, "Tie::DataUUID", "right class");
 ok($uuid ne $uuid, "it changes");
-like("$uuid $uuid", "/[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12} [A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}/", "looks good");
+like("$uuid $uuid", "/[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12} [A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}/i", "looks good");


### PR DESCRIPTION
Hey,

I wasn't able to install without making the regexes in the test case-insensitive.

Also the version on CPAN is a bit stale.

Alfie
